### PR TITLE
Fix React warning: "Warning: setState(...): Can only update a mounted or mounting component"

### DIFF
--- a/src/components/DraggableMixin.js
+++ b/src/components/DraggableMixin.js
@@ -31,6 +31,10 @@ const DraggableMixin = {
     this.rect = this.getBoundingRect();
   },
 
+  componentWillUnmount() {
+    this.stopUpdates();
+  },
+
   startUpdates(e) {
     const { document } = this;
 


### PR DESCRIPTION
This PR fixes React warning: `Warning: setState(...): Can only update a mounted or mounting component` when the ColorPicker is used inside some togglable element:

**Before:**
![](https://talkable-screenshots.s3.amazonaws.com/screencast_2018-02-08_18-28-51.gif)

**After:**
![](https://talkable-screenshots.s3.amazonaws.com/screencast_2018-02-08_18-25-20.gif)


Steps to reproduce:
1. Change `example/src/app.js` to the following content https://gist.github.com/iurevych/24bd2c388c7bbefccf4d24a62ca124ad
2. When dragging the color slider press `Esc` key